### PR TITLE
[.bandit] skip B311 (random not suitable for security/crypto)

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,4 +1,4 @@
 [bandit]
-skips: B101,B101,B404,B603,B606,B607
+skips: B101,B101,B311,B404,B603,B606,B607
 exclude: /docs
 


### PR DESCRIPTION
https://docs.openstack.org/bandit/latest/api/bandit.blacklists.html#b311-random

We don't implement any security/cryptographic related stuff, so we can ignore this.